### PR TITLE
Import Alamofire and Swizzle SessionDelegate Methods.

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Chucker.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Chucker.xcscheme
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1240"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Chucker_Chucker"
+               BuildableName = "Chucker_Chucker"
+               BlueprintName = "Chucker_Chucker"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Chucker"
+               BuildableName = "Chucker"
+               BlueprintName = "Chucker"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ChuckerTests"
+               BuildableName = "ChuckerTests"
+               BlueprintName = "ChuckerTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ChuckerTests"
+               BuildableName = "ChuckerTests"
+               BlueprintName = "ChuckerTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "Chucker_Chucker"
+            BuildableName = "Chucker_Chucker"
+            BlueprintName = "Chucker_Chucker"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Alamofire",
+        "repositoryURL": "https://github.com/Alamofire/Alamofire.git",
+        "state": {
+          "branch": null,
+          "revision": "eaf6e622dd41b07b251d8f01752eab31bc811493",
+          "version": "5.4.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -16,11 +16,12 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
+        .package(name: "Alamofire", url: "https://github.com/Alamofire/Alamofire.git", .exact("5.4.1"))
     ],
     targets: [
         .target(
             name: "Chucker",
-            dependencies: []),
+            dependencies: ["Alamofire"]),
         .testTarget(
             name: "ChuckerTests",
             dependencies: ["Chucker"])

--- a/Sources/Chucker/ChuckerViewController.swift
+++ b/Sources/Chucker/ChuckerViewController.swift
@@ -133,6 +133,11 @@ extension ChuckerViewController: UITableViewDataSource {
             }
         }
 
+        if item.response?.error != nil {
+            cell.iconView.image = UIImage(systemName: "xmark.octagon.fill")
+            cell.iconView.tintColor = .systemRed
+        }
+
         return cell
     }
 }

--- a/Sources/Chucker/NetworkTrafficManager.swift
+++ b/Sources/Chucker/NetworkTrafficManager.swift
@@ -5,6 +5,7 @@
 //  Created by Branden Smith on 3/26/21.
 //
 
+import Alamofire
 import Foundation
 
 struct NetworkRequest: Equatable, Hashable {
@@ -32,8 +33,8 @@ final class NetworkTrafficManager {
     internal var shouldRecord: Bool = false {
         didSet {
             URLSessionDataTask.swizzleResume()
-            URLSession.swizzleDataTaskWithRequest()
             URLSession.swizzleDataTaskWithRequestCompletion()
+            SessionDelegate.swizzleURLSessionTaskDidReceiveData()
         }
     }
 

--- a/Sources/Chucker/NetworkTrafficManager.swift
+++ b/Sources/Chucker/NetworkTrafficManager.swift
@@ -35,6 +35,7 @@ final class NetworkTrafficManager {
             URLSessionDataTask.swizzleResume()
             URLSession.swizzleDataTaskWithRequestCompletion()
             SessionDelegate.swizzleURLSessionTaskDidReceiveData()
+            SessionDelegate.swizzleURLSessionTaskDidCompleteWithError()
         }
     }
 

--- a/Sources/Chucker/NetworkTrafficManager.swift
+++ b/Sources/Chucker/NetworkTrafficManager.swift
@@ -32,7 +32,8 @@ final class NetworkTrafficManager {
     internal var shouldRecord: Bool = false {
         didSet {
             URLSessionDataTask.swizzleResume()
-            URLSession.swizzleDataTask()
+            URLSession.swizzleDataTaskWithRequest()
+            URLSession.swizzleDataTaskWithRequestCompletion()
         }
     }
 

--- a/Sources/Chucker/SessionDelegate+Swizzle.swift
+++ b/Sources/Chucker/SessionDelegate+Swizzle.swift
@@ -1,0 +1,36 @@
+//
+//  SessionDelegate+Swizzle.swift
+//  
+//
+//  Created by Branden Smith on 3/30/21.
+//
+
+import Alamofire
+import Foundation
+
+extension SessionDelegate {
+    static func swizzleURLSessionTaskDidReceiveData() {
+        method_exchangeImplementations(
+            class_getInstanceMethod(
+                SessionDelegate.self,
+                #selector(SessionDelegate.urlSession(_:dataTask:didReceive:))
+            )!,
+            class_getInstanceMethod(
+                SessionDelegate.self,
+                #selector(SessionDelegate.swizzledURLSessionTaskDidReceiveData(_:dataTask:didReceive:))
+            )!
+        )
+    }
+
+    @objc func swizzledURLSessionTaskDidReceiveData(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        let networkRequest = NetworkRequest(date: Date(), request: dataTask.originalRequest!)
+        networkTrafficManager.addRequest(networkRequest)
+
+        networkTrafficManager.pairResponse(
+            response: NetworkResponse(date: Date(), response: dataTask.response, data: data, error: dataTask.error),
+            with: networkRequest
+        )
+
+        return swizzledURLSessionTaskDidReceiveData(session, dataTask: dataTask, didReceive: data)
+    }
+}

--- a/Sources/Chucker/SessionDelegate+Swizzle.swift
+++ b/Sources/Chucker/SessionDelegate+Swizzle.swift
@@ -48,6 +48,10 @@ extension SessionDelegate {
     }
 
     @objc func swizzledUrlSessionTaskDidCompleteWithError(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        defer { swizzledUrlSessionTaskDidCompleteWithError(session, task: task, didCompleteWithError: error) }
+
+        guard let error = error else { return }
+
         let networkRequest = NetworkRequest(date: Date(), request: task.originalRequest!)
         networkTrafficManager.addRequest(networkRequest)
 

--- a/Sources/Chucker/URLSession+Swizzle.swift
+++ b/Sources/Chucker/URLSession+Swizzle.swift
@@ -48,6 +48,8 @@ extension URLSession {
         let networkRequest = NetworkRequest(date: Date(), request: request)
         networkTrafficManager.addRequest(networkRequest)
 
-        return swizzledDataTask(with: request)
+        return dataTask(with: request, completionHandler: { (data, response, error) in
+            // Do nothing, we expect our swizzled version of this method to insert the correct completion here.
+        })
     }
 }

--- a/Sources/Chucker/URLSession+Swizzle.swift
+++ b/Sources/Chucker/URLSession+Swizzle.swift
@@ -18,16 +18,6 @@ extension URLSession {
         )
     }
 
-    static func swizzleDataTaskWithRequest() {
-        method_exchangeImplementations(
-            class_getInstanceMethod(
-                URLSession.self,
-                #selector(URLSession.dataTask(with:) as (URLSession) -> (URLRequest) -> URLSessionDataTask)
-            )!,
-            class_getInstanceMethod(URLSession.self, #selector(swizzledDataTask(with:)))!
-        )
-    }
-
     @objc func swizzledDataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
         let networkRequest = NetworkRequest(date: Date(), request: request)
         networkTrafficManager.addRequest(networkRequest)
@@ -42,11 +32,5 @@ extension URLSession {
         }
 
         return swizzledDataTask(with: request, completionHandler: replacedCompletion)
-    }
-
-    @objc func swizzledDataTask(with request: URLRequest) -> URLSessionDataTask {
-        return dataTask(with: request, completionHandler: { (data, response, error) in
-            // Do nothing, we expect our swizzled version of this method to insert the correct completion here.
-        })
     }
 }

--- a/Sources/Chucker/URLSession+Swizzle.swift
+++ b/Sources/Chucker/URLSession+Swizzle.swift
@@ -45,9 +45,6 @@ extension URLSession {
     }
 
     @objc func swizzledDataTask(with request: URLRequest) -> URLSessionDataTask {
-        let networkRequest = NetworkRequest(date: Date(), request: request)
-        networkTrafficManager.addRequest(networkRequest)
-
         return dataTask(with: request, completionHandler: { (data, response, error) in
             // Do nothing, we expect our swizzled version of this method to insert the correct completion here.
         })


### PR DESCRIPTION
# Summary

This change adds Alamofire as a package dependency and makes use of Swizzling its SessionDelegate methods as Alamofire doesn't typically use `URLSession.dataTask(with:completionHandler:)`