### PR TITLE
Feature/Add Mocking for GraphQL queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,25 @@ Both the configuration and manifest files should be JSON files and have the foll
             "type": "success"
         }
     ],
+    "includedGraphQL": [
+        {
+            "endpoint": "https://<# graphql endpoint>",
+            "operationType": "<# operation type>",
+            "operationName": "<# operation name>",
+            "useMock": true,
+            "type": "success"
+        }
+    ],
     "excluded": [
         "<# excluded endpoint 1>",
         "<# excluded endpoint 2>"
+    ],
+    "excludedGraphQL": [
+        {
+            "endpoint": "https://<# graphql endpoint>",
+            "operationType": "<# operation type>",
+            "operationName": "<# operation name>"
+        }
     ]
 }
 ```
@@ -95,10 +111,22 @@ This file is loaded and, when data mocking is turned on, the framework consults 
 
 ```JSON
 {
-    "https://<# endpoint>": {
-        "success": "path/to/mock-response-success",
-        "failure": "path/to/mock-response-failure"
-    }
+    "rest": [
+        {
+            "endpoint": "https://<# endpoint>",
+            "success": "path/to/mock-response-success",
+            "failure": "path/to/mock-response-failure"
+        }
+    ],
+    "graphql": [
+        {
+            "endpoint": "https://<# graphql endpoint>",
+            "operationType": "<# operation type>",
+            "operationName": "<# operation name>"
+            "success": "path/to/mock-response-success",
+            "failure": "path/to/mock-response-failure"
+        }
+    ]
 }
 ```
 
@@ -113,7 +141,7 @@ Each mock response is also a JSON file with the following format:
     "httpVersion": null,
     "headerFields": {},
     "body": {
-        "question": "Test Question Fool",
+        "question": "Test Question",
         "published_at": "2015-08-05T08:40:51.620Z",
         "choices": [
             {

--- a/Sources/Chucker/Chucker.storyboard
+++ b/Sources/Chucker/Chucker.storyboard
@@ -18,73 +18,76 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="KkC-G5-Yae">
-                                <rect key="frame" x="20" y="64" width="374" height="31"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="OOq-0x-Bmm">
+                                <rect key="frame" x="20" y="54" width="374" height="72"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9el-8F-9fF">
-                                        <rect key="frame" x="0.0" y="0.0" width="129.5" height="31"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                    </view>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Record Network Traffic" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KUV-Ch-h2Q">
-                                        <rect key="frame" x="139.5" y="0.0" width="175.5" height="31"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YjU-xp-c29">
-                                        <rect key="frame" x="325" y="0.0" width="51" height="31"/>
-                                        <connections>
-                                            <action selector="recordSwitchValueChanged:" destination="yTF-Vf-PJO" eventType="valueChanged" id="Dk3-Wi-Twq"/>
-                                        </connections>
-                                    </switch>
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="KkC-G5-Yae">
+                                        <rect key="frame" x="0.0" y="0.0" width="374" height="31"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9el-8F-9fF">
+                                                <rect key="frame" x="0.0" y="0.0" width="129.5" height="31"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                            </view>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Record Network Traffic" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KUV-Ch-h2Q">
+                                                <rect key="frame" x="139.5" y="0.0" width="175.5" height="31"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YjU-xp-c29">
+                                                <rect key="frame" x="325" y="0.0" width="51" height="31"/>
+                                                <connections>
+                                                    <action selector="recordSwitchValueChanged:" destination="yTF-Vf-PJO" eventType="valueChanged" id="Dk3-Wi-Twq"/>
+                                                </connections>
+                                            </switch>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="nol-sv-2ru">
+                                        <rect key="frame" x="0.0" y="41" width="374" height="31"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Azz-iU-7db">
+                                                <rect key="frame" x="0.0" y="0.0" width="104.5" height="31"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                            </view>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enable Response Mocking" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ypu-Nv-JKy">
+                                                <rect key="frame" x="114.5" y="0.0" width="200.5" height="31"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BLq-6B-IBg">
+                                                <rect key="frame" x="325" y="0.0" width="51" height="31"/>
+                                                <connections>
+                                                    <action selector="mockDataSwitchValueChanged:" destination="yTF-Vf-PJO" eventType="valueChanged" id="33Q-DR-hgk"/>
+                                                </connections>
+                                            </switch>
+                                        </subviews>
+                                    </stackView>
                                 </subviews>
                             </stackView>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="are-jT-0tT">
-                                <rect key="frame" x="0.0" y="146" width="414" height="716"/>
+                                <rect key="frame" x="0.0" y="136" width="414" height="726"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <connections>
                                     <outlet property="dataSource" destination="yTF-Vf-PJO" id="gW1-gG-Aoa"/>
                                     <outlet property="delegate" destination="yTF-Vf-PJO" id="1Cr-br-Exe"/>
                                 </connections>
                             </tableView>
-                            <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="nol-sv-2ru">
-                                <rect key="frame" x="20" y="105" width="374" height="31"/>
-                                <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Azz-iU-7db">
-                                        <rect key="frame" x="0.0" y="0.0" width="104.5" height="31"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                    </view>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enable Response Mocking" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ypu-Nv-JKy">
-                                        <rect key="frame" x="114.5" y="0.0" width="200.5" height="31"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BLq-6B-IBg">
-                                        <rect key="frame" x="325" y="0.0" width="51" height="31"/>
-                                        <connections>
-                                            <action selector="mockDataSwitchValueChanged:" destination="yTF-Vf-PJO" eventType="valueChanged" id="33Q-DR-hgk"/>
-                                        </connections>
-                                    </switch>
-                                </subviews>
-                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="cKb-64-cfq"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="KkC-G5-Yae" firstAttribute="leading" secondItem="cKb-64-cfq" secondAttribute="leading" constant="20" id="0RQ-W1-vhO"/>
-                            <constraint firstItem="cKb-64-cfq" firstAttribute="trailing" secondItem="nol-sv-2ru" secondAttribute="trailing" constant="20" id="3bs-hD-X0I"/>
-                            <constraint firstItem="cKb-64-cfq" firstAttribute="trailing" secondItem="KkC-G5-Yae" secondAttribute="trailing" constant="20" id="Baw-1A-iyG"/>
-                            <constraint firstItem="nol-sv-2ru" firstAttribute="leading" secondItem="cKb-64-cfq" secondAttribute="leading" constant="20" id="eXk-uv-O2R"/>
+                            <constraint firstItem="cKb-64-cfq" firstAttribute="trailing" secondItem="OOq-0x-Bmm" secondAttribute="trailing" constant="20" id="237-Nv-MdA"/>
+                            <constraint firstItem="are-jT-0tT" firstAttribute="top" secondItem="OOq-0x-Bmm" secondAttribute="bottom" constant="10" id="7iC-Ua-W2A"/>
+                            <constraint firstItem="OOq-0x-Bmm" firstAttribute="leading" secondItem="cKb-64-cfq" secondAttribute="leading" constant="20" id="cQ9-WX-s3b"/>
+                            <constraint firstItem="OOq-0x-Bmm" firstAttribute="top" secondItem="cKb-64-cfq" secondAttribute="top" constant="10" id="efH-LU-p2k"/>
                             <constraint firstItem="cKb-64-cfq" firstAttribute="bottom" secondItem="are-jT-0tT" secondAttribute="bottom" id="hHf-9R-dz3"/>
-                            <constraint firstItem="KkC-G5-Yae" firstAttribute="top" secondItem="cKb-64-cfq" secondAttribute="top" constant="20" id="k2f-HG-jgj"/>
                             <constraint firstItem="are-jT-0tT" firstAttribute="leading" secondItem="cKb-64-cfq" secondAttribute="leading" id="px1-ms-oGx"/>
-                            <constraint firstItem="nol-sv-2ru" firstAttribute="top" secondItem="KkC-G5-Yae" secondAttribute="bottom" constant="10" id="qUP-2K-AKv"/>
                             <constraint firstItem="cKb-64-cfq" firstAttribute="trailing" secondItem="are-jT-0tT" secondAttribute="trailing" id="ryR-Ob-acK"/>
-                            <constraint firstItem="are-jT-0tT" firstAttribute="top" secondItem="nol-sv-2ru" secondAttribute="bottom" constant="10" id="zfC-5S-3ST"/>
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="enableResponseMockingView" destination="nol-sv-2ru" id="c6X-Xs-DeX"/>
                         <outlet property="mockingSwitch" destination="BLq-6B-IBg" id="2VY-H7-cSk"/>
                         <outlet property="recordSwitch" destination="YjU-xp-c29" id="e1a-xr-fWC"/>
                         <outlet property="tableView" destination="are-jT-0tT" id="cjn-Vr-5oL"/>

--- a/Sources/Chucker/ChuckerViewController.swift
+++ b/Sources/Chucker/ChuckerViewController.swift
@@ -15,6 +15,7 @@ public final class ChuckerViewController: UIViewController {
     @IBOutlet weak var recordSwitch: UISwitch!
     @IBOutlet weak var mockingSwitch: UISwitch!
     @IBOutlet weak var tableView: UITableView!
+    @IBOutlet weak var enableResponseMockingView: UIStackView!
 
     private lazy var noItemsView: NoItemsView = {
         let noItemsView = Bundle
@@ -48,7 +49,15 @@ public final class ChuckerViewController: UIViewController {
         super.viewDidLoad()
 
         self.recordSwitch.isOn = networkTrafficManager.shouldRecord
-        self.mockingSwitch.isOn = CommandLine.arguments.contains(String.CommandLineArgs.useMockData)
+
+        if networkTrafficManager.mockDataManager != nil {
+            self.mockingSwitch.isOn = CommandLine.arguments.contains(String.CommandLineArgs.useMockData)
+            self.enableResponseMockingView.isHidden = false
+        } else {
+            self.mockingSwitch.isOn = false
+            self.enableResponseMockingView.isHidden = true
+        }
+
         
         tableView.register(
             UINib(nibName: "NetworkListItemCell", bundle: Bundle.module),

--- a/Sources/Chucker/MockDataConfigItem.swift
+++ b/Sources/Chucker/MockDataConfigItem.swift
@@ -7,24 +7,53 @@
 
 import Foundation
 
-struct MockDataConfigItem: Decodable, Hashable {
-    enum ConfigType: String, Decodable {
-        case success
-        case failure
-    }
+enum ConfigType: String, Decodable {
+    case success
+    case failure
+}
 
+struct MockDataConfigItem: Decodable, Hashable {
     let endpoint: String
     let useMock: Bool
     let type: ConfigType
 }
 
+struct GraphQLMockDataConfigItem: Decodable {
+    enum OperationType: String, Decodable, Hashable {
+        case query
+        case mutation
+    }
+
+    let endpoint: String
+    let operationType: OperationType
+    let operationName: String
+    let useMock: Bool
+    let type: ConfigType
+
+    var key: String {
+        return endpoint
+            + operationType.rawValue
+            + operationName
+    }
+}
+
+struct GraphQLExclusion: Decodable, Hashable {
+    let endpoint: String
+    let operationType: GraphQLMockDataConfigItem.OperationType
+    let operationName: String
+}
+
 struct MockDataConfig: Decodable {
     let included: [String: MockDataConfigItem]
+    let includedGraphQL: [String: GraphQLMockDataConfigItem]
     let excluded: Set<String>
+    let excludedGraphQL: Set<GraphQLExclusion>
 
     enum CodingKeys: String, CodingKey {
         case included
+        case includedGraphQL
         case excluded
+        case excludedGraphQL
     }
 
     init(from decoder: Decoder) throws {
@@ -35,7 +64,15 @@ struct MockDataConfig: Decodable {
             result[item.endpoint] = item
         })
 
+        let includedGraphQLItems = (try? container.decodeIfPresent([GraphQLMockDataConfigItem].self, forKey: .includedGraphQL)) ?? []
+        includedGraphQL = includedGraphQLItems.reduce(into: [:], { (result, item) in
+            result[item.key] = item
+        })
+
         let excludedItems: [String] = try container.decodeIfPresent([String].self, forKey: .excluded) ?? []
         excluded = Set(excludedItems)
+
+        let excludedGraphQLItems = (try? container.decodeIfPresent([GraphQLExclusion].self, forKey: .excludedGraphQL)) ?? []
+        excludedGraphQL = Set(excludedGraphQLItems)
     }
 }

--- a/Sources/Chucker/MockDataConfigItem.swift
+++ b/Sources/Chucker/MockDataConfigItem.swift
@@ -31,9 +31,8 @@ struct GraphQLMockDataConfigItem: Decodable {
     let type: ConfigType
 
     var key: String {
-        return endpoint
-            + operationType.rawValue
-            + operationName
+        return "\(endpoint)\(operationType.rawValue)\(operationName)"
+            .replacingOccurrences(of: "/", with: "")
     }
 }
 

--- a/Sources/Chucker/MockDataManager.swift
+++ b/Sources/Chucker/MockDataManager.swift
@@ -43,11 +43,14 @@ final class MockDataManager {
 
         if let graphQLOperationType = request.allHTTPHeaderFields?[apolloOperationTypeHeader],
            let graphQLOperationName = request.allHTTPHeaderFields?[apolloOperationNameHeader] {
+            let key = "\(endpoint)\(graphQLOperationType)\(graphQLOperationName)"
+                .replacingOccurrences(of: "/", with: "")
+
             return MockResponseDecoder()
                 .decodeMockResponse(
                     from: try! data(
-                        for: workingManifest.items[endpoint + graphQLOperationType + graphQLOperationName]!.value(
-                            for: workingConfig.includedGraphQL[endpoint + graphQLOperationType + graphQLOperationName]!.type
+                        for: workingManifest.graphqlItems[key]!.value(
+                            for: workingConfig.includedGraphQL[key]!.type
                         ),
                         in: bundle
                     )
@@ -56,7 +59,7 @@ final class MockDataManager {
             return MockResponseDecoder()
                 .decodeMockResponse(
                     from: try! data(
-                        for: workingManifest.items[endpoint]!.value(
+                        for: workingManifest.restItems[endpoint]!.value(
                             for: workingConfig.included[endpoint]!.type
                         ),
                         in: bundle

--- a/Sources/Chucker/MockDataManager.swift
+++ b/Sources/Chucker/MockDataManager.swift
@@ -78,9 +78,8 @@ final class MockDataManager {
         guard let opertationName = request.allHTTPHeaderFields?[apolloOperationNameHeader] else { return false }
 
         let endpoint = request.url!.absoluteString.components(separatedBy: "?")[0]
-        let graphQLKey = endpoint
-            + operationType
-            + opertationName
+        let graphQLKey = "\(endpoint)\(operationType)\(opertationName)"
+            .replacingOccurrences(of: "/", with: "")
 
         return !workingConfig.excludedGraphQL.contains(
             where: { (item) in

--- a/Sources/Chucker/MockDataManifest.swift
+++ b/Sources/Chucker/MockDataManifest.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct ManifestItem: Decodable {
+    let endpoint: String
     let success: String
     let failure: String
 
@@ -21,28 +22,48 @@ struct ManifestItem: Decodable {
     }
 }
 
+struct GraphQLManifestItem: Decodable {
+    let endpoint: String
+    let operationType: String
+    let operationName: String
+    let success: String
+    let failure: String
+
+    var key: String {
+        return "\(endpoint)\(operationType)\(operationName)"
+            .replacingOccurrences(of: "/", with: "")
+    }
+
+    func value(for configType: ConfigType) -> String {
+        switch configType {
+        case .success:
+            return success
+        case .failure:
+            return failure
+        }
+    }
+}
+
 struct MockDataManifest: Decodable {
-    let items: [String: ManifestItem]
+    let restItems: [String: ManifestItem]
+    let graphqlItems: [String: GraphQLManifestItem]
 
-    private struct DynamicCodingKeys: CodingKey {
-        var intValue: Int?
-        var stringValue: String
-
-        init?(stringValue: String) {
-            self.stringValue = stringValue
-        }
-
-        init?(intValue: Int) {
-            return nil
-        }
+    private enum CodingKeys: String, CodingKey {
+        case rest
+        case graphql
     }
 
     init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: DynamicCodingKeys.self)
+        let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        items = try container.allKeys.reduce(into: [:], { (result, key) in
-            let item = try container.decode(ManifestItem.self, forKey: DynamicCodingKeys(stringValue: key.stringValue)!)
-            result[key.stringValue] = item
+        let rest: [ManifestItem] = (try? container.decode([ManifestItem].self, forKey: .rest)) ?? []
+        restItems = rest.reduce(into: [:], { (result, item) in
+            result[item.endpoint] = item
+        })
+
+        let graphql: [GraphQLManifestItem] = (try? container.decode([GraphQLManifestItem].self, forKey: .graphql)) ?? []
+        graphqlItems = graphql.reduce(into: [:], { (result, item) in
+            result[item.key] = item
         })
     }
 }

--- a/Sources/Chucker/MockDataManifest.swift
+++ b/Sources/Chucker/MockDataManifest.swift
@@ -11,7 +11,7 @@ struct ManifestItem: Decodable {
     let success: String
     let failure: String
 
-    func value(for configType: MockDataConfigItem.ConfigType) -> String {
+    func value(for configType: ConfigType) -> String {
         switch configType {
         case .success:
             return success

--- a/Sources/Chucker/URLSession+Swizzle.swift
+++ b/Sources/Chucker/URLSession+Swizzle.swift
@@ -63,7 +63,7 @@ extension URLSession {
         if CommandLine.arguments.contains(String.CommandLineArgs.useMockData) {
             let shouldMock = try? networkTrafficManager
                 .mockDataManager?
-                .shouldMockResponse(for: request.url!.absoluteString.components(separatedBy: "?")[0])
+                .shouldMockResponse(for: request)
 
             if shouldMock ?? false {
                 let fakeTask = FakeURLSessionTask(

--- a/Sources/Chucker/URLSession+Swizzle.swift
+++ b/Sources/Chucker/URLSession+Swizzle.swift
@@ -84,7 +84,7 @@ final class FakeURLSessionTask: URLSessionDataTask {
     override func resume() {
         let start = Date()
         let mockResponse = try! networkTrafficManager.mockDataManager!.mockResponse(
-            for: _originalRequest.url!.absoluteString.components(separatedBy: "?")[0]
+            for: _originalRequest
         )
 
         let bytesToSend = Int64(_originalRequest.httpBody?.count ?? 0)


### PR DESCRIPTION
# Summary

This change adds mocking for GraphQL queries. As they typically all have the same endpoint, the change accounts for headers specifying that the request is GraphQL and makes use of the operation type and operation name to match configuration items to manifest items to provide the appropriate mock. 