### PR TITLE
Add live mock data configuration editing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,14 @@ Both the configuration and manifest files should be JSON files and have the foll
 {
     "included": [
         {
+            "name": "<# plain text name/description of endpoint>",
             "endpoint": "https://<# endpoint>",
             "method": "GET",
             "useMock": false,
             "responseKey": "success"
         },
         {
+            "name": "<# plain text name/description of endpoint>",
             "endpoint": "https://graphql.<# endpoint>",
             "method": "POST",
             "operationType": "query",

--- a/Sources/Chucker/Chucker.storyboard
+++ b/Sources/Chucker/Chucker.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="yTF-Vf-PJO">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="yTF-Vf-PJO">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -19,7 +19,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="OOq-0x-Bmm">
-                                <rect key="frame" x="20" y="54" width="374" height="72"/>
+                                <rect key="frame" x="20" y="54" width="374" height="112"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="KkC-G5-Yae">
                                         <rect key="frame" x="0.0" y="0.0" width="374" height="31"/>
@@ -63,10 +63,21 @@
                                             </switch>
                                         </subviews>
                                     </stackView>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lHe-Hg-K8e">
+                                        <rect key="frame" x="0.0" y="82" width="374" height="30"/>
+                                        <color key="backgroundColor" systemColor="linkColor"/>
+                                        <state key="normal" title="Edit Mocking Configuration">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="editMockConfigButtonTouched:" destination="yTF-Vf-PJO" eventType="touchUpInside" id="hMf-XI-P6b"/>
+                                            <segue destination="Vs3-RN-EeB" kind="show" identifier="showEditConfig" id="qTz-9f-mwr"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
                             </stackView>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="are-jT-0tT">
-                                <rect key="frame" x="0.0" y="136" width="414" height="726"/>
+                                <rect key="frame" x="0.0" y="176" width="414" height="686"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <connections>
                                     <outlet property="dataSource" destination="yTF-Vf-PJO" id="gW1-gG-Aoa"/>
@@ -87,6 +98,7 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="editMockConfigButton" destination="lHe-Hg-K8e" id="7kw-8i-KF4"/>
                         <outlet property="enableResponseMockingView" destination="nol-sv-2ru" id="c6X-Xs-DeX"/>
                         <outlet property="mockingSwitch" destination="BLq-6B-IBg" id="2VY-H7-cSk"/>
                         <outlet property="recordSwitch" destination="YjU-xp-c29" id="e1a-xr-fWC"/>
@@ -97,6 +109,41 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="wz6-Se-b04" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="11.594202898550726" y="89.732142857142847"/>
+        </scene>
+        <!--Edit Mock Data Config View Controller-->
+        <scene sceneID="Grb-8u-EJQ">
+            <objects>
+                <viewController id="Vs3-RN-EeB" customClass="EditMockDataConfigViewController" customModule="Chucker" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="MRd-VF-JVM">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="tfU-gM-OG1">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <connections>
+                                    <outlet property="dataSource" destination="Vs3-RN-EeB" id="zfp-73-UJv"/>
+                                    <outlet property="delegate" destination="Vs3-RN-EeB" id="yVH-DH-mVA"/>
+                                </connections>
+                            </tableView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="2N4-GD-qYI"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="2N4-GD-qYI" firstAttribute="bottom" secondItem="tfU-gM-OG1" secondAttribute="bottom" id="3K5-vw-ce3"/>
+                            <constraint firstItem="2N4-GD-qYI" firstAttribute="trailing" secondItem="tfU-gM-OG1" secondAttribute="trailing" id="YDH-FZ-MGK"/>
+                            <constraint firstItem="tfU-gM-OG1" firstAttribute="leading" secondItem="2N4-GD-qYI" secondAttribute="leading" id="pW3-SF-cdi"/>
+                            <constraint firstItem="tfU-gM-OG1" firstAttribute="top" secondItem="2N4-GD-qYI" secondAttribute="top" id="uba-3Y-lV0"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="Zjj-xg-mkt"/>
+                    <connections>
+                        <outlet property="tableView" destination="tfU-gM-OG1" id="YxT-eV-VF5"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Iqm-3h-fja" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="938" y="461"/>
         </scene>
         <!--Network Item Detail View Controller-->
         <scene sceneID="2yM-Er-Rf5">
@@ -182,13 +229,16 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Q76-VY-YLM" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="811.59420289855075" y="89.732142857142847"/>
+            <point key="canvasLocation" x="938" y="-263"/>
         </scene>
     </scenes>
     <resources>
         <image name="arrowtriangle.down.fill" catalog="system" width="128" height="124"/>
         <systemColor name="labelColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="linkColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/Sources/Chucker/ChuckerViewController.swift
+++ b/Sources/Chucker/ChuckerViewController.swift
@@ -16,6 +16,7 @@ public final class ChuckerViewController: UIViewController {
     @IBOutlet weak var mockingSwitch: UISwitch!
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var enableResponseMockingView: UIStackView!
+    @IBOutlet weak var editMockConfigButton: UIButton!
 
     private lazy var noItemsView: NoItemsView = {
         let noItemsView = Bundle
@@ -49,20 +50,23 @@ public final class ChuckerViewController: UIViewController {
         super.viewDidLoad()
 
         self.recordSwitch.isOn = networkTrafficManager.shouldRecord
+        self.editMockConfigButton.layer.cornerRadius = 5.0
 
         if networkTrafficManager.mockDataManager != nil {
             self.mockingSwitch.isOn = CommandLine.arguments.contains(String.CommandLineArgs.useMockData)
             self.enableResponseMockingView.isHidden = false
+            self.editMockConfigButton.isHidden = !self.mockingSwitch.isOn
         } else {
             self.mockingSwitch.isOn = false
             self.enableResponseMockingView.isHidden = true
+            self.editMockConfigButton.isHidden = true
         }
 
-        
         tableView.register(
             UINib(nibName: "NetworkListItemCell", bundle: Bundle.module),
             forCellReuseIdentifier: "NetworkListItemCell"
         )
+        tableView.tableFooterView = UIView(frame: CGRect.zero)
 
         setupLogItemsSubscription()
     }
@@ -108,6 +112,8 @@ public final class ChuckerViewController: UIViewController {
     }
 
     @IBAction func mockDataSwitchValueChanged(_ sender: UISwitch) {
+        self.editMockConfigButton.isHidden = !sender.isOn
+
         if sender.isOn {
             if !CommandLine.arguments.contains(String.CommandLineArgs.useMockData) {
                 CommandLine.arguments.append(String.CommandLineArgs.useMockData)
@@ -115,6 +121,10 @@ public final class ChuckerViewController: UIViewController {
         } else {
             CommandLine.arguments.removeAll(where: { $0.contains(String.CommandLineArgs.useMockData)})
         }
+    }
+
+    @IBAction func editMockConfigButtonTouched(_ sender: UIButton) {
+        
     }
 }
 

--- a/Sources/Chucker/ConfigItemPickerViewManager.swift
+++ b/Sources/Chucker/ConfigItemPickerViewManager.swift
@@ -1,0 +1,63 @@
+//
+//  ConfigItemPickerViewManager.swift
+//  
+//
+//  Created by Branden Smith on 5/4/21.
+//
+
+import Foundation
+import UIKit
+
+protocol ConfigItemPickerViewManagerDelegate: AnyObject {
+    func configItemManager(didSelectResponseKey key: String, for managedItemKey: String)
+}
+
+final class ConfigItemPickerViewManager: NSObject {
+    private(set) var selectedIndex: Int
+
+    private let managedItemKey: String
+    private weak var delegate: ConfigItemPickerViewManagerDelegate?
+
+    private let pickerItems: [String]
+
+    var isEditing: Bool = false
+
+    init(managedItem: MockDataConfigItem, delegate: ConfigItemPickerViewManagerDelegate) {
+        self.managedItemKey = managedItem.key
+        self.delegate = delegate
+
+        self.pickerItems = networkTrafficManager
+            .mockDataManager!
+            .workingManifest
+            .items[managedItemKey]!
+            .responseMap
+            .keys
+            .sorted(by: { $0 < $1 })
+
+        self.selectedIndex = self.pickerItems.firstIndex(where: { $0 == managedItem.responseKey })!
+
+        super.init()
+    }
+}
+
+extension ConfigItemPickerViewManager: UIPickerViewDataSource {
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 1
+    }
+
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        return pickerItems.count
+    }
+}
+
+extension ConfigItemPickerViewManager: UIPickerViewDelegate {
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        return pickerItems[row]
+    }
+
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        self.selectedIndex = row
+        isEditing = false
+        delegate?.configItemManager(didSelectResponseKey: pickerItems[row], for: managedItemKey)
+    }
+}

--- a/Sources/Chucker/EditMockDataConfigViewController.swift
+++ b/Sources/Chucker/EditMockDataConfigViewController.swift
@@ -1,0 +1,170 @@
+//
+//  EditMockDataConfigViewController.swift
+//  
+//
+//  Created by Branden Smith on 5/4/21.
+//
+
+import Foundation
+import UIKit
+
+final class EditMockDataConfigViewController: UIViewController {
+    @IBOutlet weak var tableView: UITableView!
+
+    private lazy var items: [MockDataConfigItem] = {
+        return networkTrafficManager
+            .mockDataManager!
+            .workingConfig
+            .included
+            .values
+            .sorted(by: { $0.name < $1.name })
+    }()
+
+    private lazy var pickerManagers: [ConfigItemPickerViewManager] = {
+        return items.map({ ConfigItemPickerViewManager(managedItem: $0, delegate: self) })
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = "Edit Config"
+        
+        tableView.estimatedRowHeight = 200.0
+        tableView.rowHeight = UITableView.automaticDimension
+        
+        tableView.register(
+            UINib(nibName: "MockDataConfigItemCell", bundle: Bundle.module),
+            forCellReuseIdentifier: "MockDataConfigItemCell"
+        )
+
+        tableView.register(
+            UINib(
+                nibName: "PickerCell",
+                bundle: Bundle.module
+            ),
+            forCellReuseIdentifier: "PickerCell"
+        )
+        tableView.tableFooterView = UIView(frame: CGRect.zero)
+    }
+}
+
+extension EditMockDataConfigViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return networkTrafficManager.mockDataManager!.workingConfig.included.count * 2
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        if indexPath.row % 2 == 0 {
+            return configureMockDataConfigItemCell(for: tableView, at: indexPath)
+        } else {
+            return configurePcikerCell(for: tableView, at: indexPath)
+        }
+    }
+
+    private func configureMockDataConfigItemCell(for tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "MockDataConfigItemCell") as! MockDataConfigItemCell
+        let index = convertIndex(indexPath.row)
+
+        let item = items[index]
+
+        cell.delegate = self
+
+        cell.nameLabel.text = item.name
+        cell.endpointLabel.text = item.endpoint
+        cell.methodLabel.text = item.method
+
+        cell.operationTypeLabel.isHidden = item.operationType == nil
+        cell.operationTypeLabel.text = item.operationType
+
+        cell.operationNameLabel.isHidden = item.operationName == nil
+        cell.operationNameLabel.text = item.operationName
+
+        cell.useMockLabel.text = "Use Mock Data"
+        cell.useMockSwitch.isOn = item.useMock
+
+        cell.responseKeyLabel.text = "Response Key: \(item.responseKey)"
+
+        return cell
+    }
+
+    private func configurePcikerCell(for tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "PickerCell") as! PickerCell
+        let index = convertIndex(indexPath.row)
+
+        cell.pickerView.dataSource = pickerManagers[index]
+        cell.pickerView.delegate = pickerManagers[index]
+        cell.pickerView.isHidden = !pickerManagers[index].isEditing
+
+        cell.pickerView.selectRow(
+            pickerManagers[index].selectedIndex,
+            inComponent: 0,
+            animated: false
+        )
+
+        return cell
+    }
+
+    func convertIndex(_ index: Int) -> Int {
+        return index / 2
+    }
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        if indexPath.row % 2 == 0 {
+            return UITableView.automaticDimension
+        } else {
+            return pickerManagers[convertIndex(indexPath.row)].isEditing ? 104.0 : 0.0
+        }
+    }
+}
+
+extension EditMockDataConfigViewController: UITableViewDelegate {
+
+}
+
+extension EditMockDataConfigViewController: ConfigItemPickerViewManagerDelegate {
+    func configItemManager(didSelectResponseKey key: String, for managedItemKey: String) {
+        let originalItem = networkTrafficManager.mockDataManager!.workingConfig.included[managedItemKey]!
+        let newItem = MockDataConfigItem(
+            name: originalItem.name,
+            endpoint: originalItem.endpoint,
+            method: originalItem.method,
+            operationName: originalItem.operationName,
+            operationType: originalItem.operationType,
+            useMock: originalItem.useMock,
+            responseKey: key
+        )
+
+        networkTrafficManager.mockDataManager?.workingConfig.included[managedItemKey] = newItem
+
+        let itemIndex = items.firstIndex(where: { $0.key == managedItemKey })!
+        items[itemIndex] = newItem
+
+        tableView.reloadRows(at: [IndexPath(row: itemIndex, section: 0)], with: .automatic)
+    }
+}
+
+extension EditMockDataConfigViewController: MockDataConfigItemCellDelegate {
+    func configItemCellIsEditingResponseKey(_ cell: MockDataConfigItemCell) {
+        let cellIndex = tableView.indexPath(for: cell)!.row
+        let pickerIndex = IndexPath(row: cellIndex + 1, section: 0)
+
+        pickerManagers[convertIndex(cellIndex)].isEditing = true
+        (tableView.reloadRows(at: [pickerIndex], with: .automatic))
+    }
+
+    func configItemCell(_ cell: MockDataConfigItemCell, valueForUseMockChangedTo newValue: Bool) {
+        let index = convertIndex(tableView.indexPath(for: cell)!.row)
+        let originalItem = items[index]
+        let newItem = MockDataConfigItem(
+            name: originalItem.name,
+            endpoint: originalItem.endpoint,
+            method: originalItem.method,
+            operationName: originalItem.operationName,
+            operationType: originalItem.operationType,
+            useMock: newValue,
+            responseKey: originalItem.responseKey
+        )
+
+        networkTrafficManager.mockDataManager?.workingConfig.included[originalItem.key] = newItem
+    }
+}

--- a/Sources/Chucker/MockDataConfigItem.swift
+++ b/Sources/Chucker/MockDataConfigItem.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct MockDataConfigItem: Decodable, Hashable {
+    let name: String
     let endpoint: String
     let method: String
     let operationName: String?
@@ -26,8 +27,8 @@ struct MockDataConfigItem: Decodable, Hashable {
 }
 
 struct MockDataConfig: Decodable {
-    let included: [String: MockDataConfigItem]
-    let excluded: Set<String>
+    var included: [String: MockDataConfigItem]
+    var excluded: Set<String>
 
     enum CodingKeys: String, CodingKey {
         case included

--- a/Sources/Chucker/MockDataConfigItemCell.swift
+++ b/Sources/Chucker/MockDataConfigItemCell.swift
@@ -1,0 +1,46 @@
+//
+//  MockDataConfigItemCell.swift
+//  
+//
+//  Created by Branden Smith on 5/4/21.
+//
+
+import Foundation
+import UIKit
+
+protocol MockDataConfigItemCellDelegate: AnyObject {
+    func configItemCellIsEditingResponseKey(_ cell: MockDataConfigItemCell)
+    func configItemCell(_ cell: MockDataConfigItemCell, valueForUseMockChangedTo newValue: Bool)
+}
+
+final class MockDataConfigItemCell: UITableViewCell {
+    @IBOutlet weak var nameLabel: UILabel!
+    @IBOutlet weak var endpointLabel: UILabel!
+    @IBOutlet weak var methodLabel: UILabel!
+    @IBOutlet weak var operationTypeLabel: UILabel!
+    @IBOutlet weak var operationNameLabel: UILabel!
+    @IBOutlet weak var useMockLabel: UILabel!
+    @IBOutlet weak var useMockSwitch: UISwitch!
+    @IBOutlet weak var responseKeyLabel: UILabel!
+
+    weak var delegate: MockDataConfigItemCellDelegate?
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+
+        useMockSwitch.addTarget(self, action: #selector(useMockSwitchValueChanged(_:)), for: .valueChanged)
+
+        responseKeyLabel.isUserInteractionEnabled = true
+        responseKeyLabel.addGestureRecognizer(
+            UITapGestureRecognizer(target: self, action: #selector(responseKeyLabelTapped(_:)))
+        )
+    }
+
+    @objc private func responseKeyLabelTapped(_ sender: UITapGestureRecognizer) {
+        delegate?.configItemCellIsEditingResponseKey(self)
+    }
+
+    @objc private func useMockSwitchValueChanged(_ sender: UISwitch) {
+        delegate?.configItemCell(self, valueForUseMockChangedTo: sender.isOn)
+    }
+}

--- a/Sources/Chucker/MockDataConfigItemCell.xib
+++ b/Sources/Chucker/MockDataConfigItemCell.xib
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="194" id="mla-Ix-ant" customClass="MockDataConfigItemCell" customModule="Chucker">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="194"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="mla-Ix-ant" id="P2h-zc-fNV">
+                <rect key="frame" x="0.0" y="0.0" width="414" height="194"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Wl4-fW-Ftg">
+                        <rect key="frame" x="20" y="10" width="374" height="174"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="awu-T1-d50">
+                                <rect key="frame" x="0.0" y="0.0" width="374" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" minimumFontSize="5" translatesAutoresizingMaskIntoConstraints="NO" id="oXB-4i-Mdc">
+                                <rect key="frame" x="0.0" y="25.5" width="374" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GL9-PB-CZb">
+                                <rect key="frame" x="0.0" y="51" width="374" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BMR-Gb-SYN">
+                                <rect key="frame" x="0.0" y="76.5" width="374" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b73-Uy-UUq">
+                                <rect key="frame" x="0.0" y="102" width="374" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="9xC-48-crl">
+                                <rect key="frame" x="0.0" y="127.5" width="374" height="21"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DBb-Eb-Knc">
+                                        <rect key="frame" x="0.0" y="0.5" width="325" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5wQ-CB-EaR">
+                                        <rect key="frame" x="325" y="0.5" width="51" height="20.5"/>
+                                    </switch>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="5wQ-CB-EaR" firstAttribute="height" secondItem="DBb-Eb-Knc" secondAttribute="height" id="gXP-3m-u6T"/>
+                                </constraints>
+                            </stackView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="999" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eRE-cb-oK2">
+                                <rect key="frame" x="0.0" y="153.5" width="374" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="Wl4-fW-Ftg" firstAttribute="leading" secondItem="P2h-zc-fNV" secondAttribute="leading" constant="20" id="JoE-JJ-ICo"/>
+                    <constraint firstAttribute="bottom" secondItem="Wl4-fW-Ftg" secondAttribute="bottom" constant="10" id="OTv-sD-493"/>
+                    <constraint firstItem="Wl4-fW-Ftg" firstAttribute="top" secondItem="P2h-zc-fNV" secondAttribute="top" constant="10" id="iLw-RO-wFo"/>
+                    <constraint firstAttribute="trailing" secondItem="Wl4-fW-Ftg" secondAttribute="trailing" constant="20" id="xxa-j5-Y3t"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="endpointLabel" destination="oXB-4i-Mdc" id="dnN-TW-oe0"/>
+                <outlet property="methodLabel" destination="GL9-PB-CZb" id="Ejo-KT-LxK"/>
+                <outlet property="nameLabel" destination="awu-T1-d50" id="R2j-6N-IYH"/>
+                <outlet property="operationNameLabel" destination="b73-Uy-UUq" id="9UH-VR-wcU"/>
+                <outlet property="operationTypeLabel" destination="BMR-Gb-SYN" id="ORC-dk-N8X"/>
+                <outlet property="responseKeyLabel" destination="eRE-cb-oK2" id="Za5-v2-wh7"/>
+                <outlet property="useMockLabel" destination="DBb-Eb-Knc" id="cZf-xt-6fW"/>
+                <outlet property="useMockSwitch" destination="5wQ-CB-EaR" id="2Ds-uN-0h2"/>
+            </connections>
+            <point key="canvasLocation" x="140.57971014492756" y="-79.017857142857139"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/Sources/Chucker/MockDataManager.swift
+++ b/Sources/Chucker/MockDataManager.swift
@@ -18,8 +18,8 @@ final class MockDataManager {
     private let manifest: String
     private let bundle: Bundle
 
-    private var workingManifest: MockDataManifest!
-    private var workingConfig: MockDataConfig!
+    internal var workingManifest: MockDataManifest!
+    internal var workingConfig: MockDataConfig!
 
     fileprivate static let apolloOperationTypeHeader = "X-APOLLO-OPERATION-TYPE"
     fileprivate static let apolloOperationNameHeader = "X-APOLLO-OPERATION-NAME"

--- a/Sources/Chucker/PickerCell.swift
+++ b/Sources/Chucker/PickerCell.swift
@@ -1,0 +1,13 @@
+//
+//  PickerCell.swift
+//  
+//
+//  Created by Branden Smith on 5/6/21.
+//
+
+import Foundation
+import UIKit
+
+final class PickerCell: UITableViewCell {
+    @IBOutlet weak var pickerView: UIPickerView!
+}

--- a/Sources/Chucker/PickerCell.xib
+++ b/Sources/Chucker/PickerCell.xib
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="104" id="Xm7-vL-pG5" customClass="PickerCell" customModule="Chucker">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="104"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Xm7-vL-pG5" id="vbY-ge-ihg">
+                <rect key="frame" x="0.0" y="0.0" width="414" height="104"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="bLs-HB-lQf">
+                        <rect key="frame" x="20" y="0.0" width="374" height="104"/>
+                        <subviews>
+                            <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dtJ-WD-Ynz">
+                                <rect key="frame" x="0.0" y="0.0" width="374" height="104"/>
+                            </pickerView>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="bLs-HB-lQf" firstAttribute="top" secondItem="vbY-ge-ihg" secondAttribute="top" id="6aV-HA-0SX"/>
+                    <constraint firstAttribute="bottom" secondItem="bLs-HB-lQf" secondAttribute="bottom" id="YPr-eI-C83"/>
+                    <constraint firstItem="bLs-HB-lQf" firstAttribute="leading" secondItem="vbY-ge-ihg" secondAttribute="leading" constant="20" id="gWc-us-Rna"/>
+                    <constraint firstAttribute="trailing" secondItem="bLs-HB-lQf" secondAttribute="trailing" constant="20" id="sRc-5N-nip"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="pickerView" destination="dtJ-WD-Ynz" id="Dm7-dm-qjD"/>
+            </connections>
+            <point key="canvasLocation" x="66.666666666666671" y="-40.178571428571423"/>
+        </tableViewCell>
+    </objects>
+</document>


### PR DESCRIPTION
# Summary

This change adds the ability to edit the configuration live. When data mocking is turned on, there is now
a button that allows editing the configuration live so that mocking and response types can be turned on
and off and changed without needing to rebuild and reload the configuration.