### PR TITLE
Fix Path Param Logic

### DIFF
--- a/Sources/Chucker/MockDataManager.swift
+++ b/Sources/Chucker/MockDataManager.swift
@@ -71,27 +71,31 @@ final class MockDataManager {
 
             guard tokenizedItem.count == tokenizedEndpoint.count - pathParamIndicies.count else { continue }
 
-            for index in pathParamIndicies {
-                tokenizedEndpoint.remove(at: index)
+            var tokenizedEndpointCopy: [String] = []
+
+            for item in tokenizedEndpoint.enumerated() {
+                if !pathParamIndicies.contains(item.offset) {
+                    tokenizedEndpointCopy.append(item.element)
+                }
             }
 
-            let joinedKey = tokenizedEndpoint.joined(separator: "/")
+            let joinedKey = tokenizedEndpointCopy.joined(separator: "/")
             let joinedItem = tokenizedItem.joined(separator: "/")
 
-            if joinedKey == joinedItem {
-                let shouldMock = workingConfig[joinedKey]!.configItem.useMock
-                let responseKey = workingConfig[joinedKey]!.configItem.responseKey
+            guard joinedKey == joinedItem else { continue }
 
-                if !shouldMock { return nil }
+            let shouldMock = workingConfig[joinedKey]!.configItem.useMock
+            let responseKey = workingConfig[joinedKey]!.configItem.responseKey
 
-                return MockResponseDecoder()
-                    .decodeMockResponse(
-                        from: try! data(
-                            for: workingConfig[joinedKey]!.manifestItem.responseMap[responseKey]!,
-                            in: bundle
-                        )
+            if !shouldMock { return nil }
+
+            return MockResponseDecoder()
+                .decodeMockResponse(
+                    from: try! data(
+                        for: workingConfig[joinedKey]!.manifestItem.responseMap[responseKey]!,
+                        in: bundle
                     )
-            }
+                )
         }
 
         return nil

--- a/Sources/Chucker/MockDataManager.swift
+++ b/Sources/Chucker/MockDataManager.swift
@@ -75,7 +75,7 @@ final class MockDataManager {
 
             for item in tokenizedEndpoint.enumerated() {
                 if !pathParamIndicies.contains(item.offset) {
-                    tokenizedEndpointCopy.append(item.element)
+                    tokenizedEndpointCopy.append(String(item.element))
                 }
             }
 


### PR DESCRIPTION
# Summary

This change addresses a couple of issues with the path param logic. When removing indices from the tokenized endpoint, incorrect elements would have been removed after the first removal as now the tokenized array is a different size. The change also makes a comparison to ensure that the item and endpoint match after the removal of the path parameters. 